### PR TITLE
Rename library to docgram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# doc-graph
+# docgram
 
 Gera diagramas UML no formato [Mermaid](https://mermaid.js.org/) a partir de arquivos de código. Atualmente suporta projetos TypeScript e reconhece classes, interfaces, tipos e enums com construtores, parâmetros, tipos de atributos, retornos de métodos, modificadores de acesso e relacionamentos. As entidades são agrupadas por namespaces seguindo a hierarquia de diretórios. A arquitetura permite adicionar outros parsers no futuro.
 
@@ -7,15 +7,15 @@ Gera diagramas UML no formato [Mermaid](https://mermaid.js.org/) a partir de arq
 ### Global
 
 ```bash
-npm install -g doc-graph
+npm install -g docgram
 ```
 
 ### Local
 
 ```bash
-npm install doc-graph
+npm install docgram
 # ou usando npx
-npx doc-graph diagram src
+npx docgram diagram src
 ```
 
 ## Uso
@@ -23,19 +23,19 @@ npx doc-graph diagram src
 ### Gerar diagrama no console
 
 ```bash
-doc-graph diagram <caminho-do-arquivo-ou-pasta>
+docgram diagram <caminho-do-arquivo-ou-pasta>
 ```
 
 #### Utilizando o parser LSP
 
 ```bash
-doc-graph diagram --parser lsp <caminho-do-arquivo-ou-pasta>
+docgram diagram --parser lsp <caminho-do-arquivo-ou-pasta>
 ```
 
 ### Gerar README.md com o diagrama
 
 ```bash
-doc-graph docs <caminho-do-arquivo-ou-pasta>
+docgram docs <caminho-do-arquivo-ou-pasta>
 ```
 
 ## Desenvolvimento

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "doc-graph",
+  "name": "docgram",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "doc-graph",
+      "name": "docgram",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -14,6 +14,9 @@
         "typescript-language-server": "^4.4.0",
         "vscode-jsonrpc": "^8.2.0",
         "vscode-languageserver-protocol": "^3.17.5"
+      },
+      "bin": {
+        "docgram": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "doc-graph",
+  "name": "docgram",
   "version": "1.0.0",
   "description": "Generate diagrams from source code",
   "main": "dist/index.js",
   "bin": {
-    "doc-graph": "dist/index.js"
+    "docgram": "dist/index.js"
   },
   "files": ["dist"],
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { StdioLanguageClient } from './infrastructure/lsp/stdioClient.js';
 
 const program = new Command();
 
-program.name('doc-graph').description('Generate diagrams from source code');
+program.name('docgram').description('Generate diagrams from source code');
 
 function buildService(parserOption: string) {
   const generator = new MermaidDiagramGenerator();


### PR DESCRIPTION
## Summary
- rename package and CLI from doc-graph to docgram
- update documentation to new name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c70777c483218c160198381c6fd7